### PR TITLE
HMS-16200 feat: cache ad breaks and allow custom cache duration

### DIFF
--- a/src/AdTrackingPlaybackSessionProvider.tsx
+++ b/src/AdTrackingPlaybackSessionProvider.tsx
@@ -16,9 +16,7 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
     const ISSTREAM_QUERY_PARAM = "isstream";
     const DASH_LOCATION_ELEMENT_NAME = "Location";
 
-    const LIVE_METADATA_TIMESPAN_MS = 120000
     const MIN_METADATA_INTERVAL_MS = 2000
-    const MIN_METADATA_LOOK_AHEAD_MS = 5000 // to avoid missing ads, it should be larger than MIN_METADATA_INTERVAL_MS
 
     const history = useHistory();
     const location = useLocation();
@@ -38,11 +36,11 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
         initRequest: true,
         manifestUrl: null,
         adTrackingMetadataUrl: "",
+        podRetentionMinutes: 120,
     });
     const [lastPlayheadTime, setLastPlayheadTime] = useState(0);
     const [adPods, setAdPods] = useState<any>([]);
     const [lastDataRange, setLastDataRange] = useState<DataRange | null>(null);
-    const [liveEdge, setLiveEdge] = useState(0);
 
     const getInitRequestInfo = useCallback(async (url: string) => {
         let manifestUrl = "";
@@ -182,7 +180,7 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
         }
     }, [errorContext]);
 
-    const loadMedia = useCallback(async (url, lowLatencyMode: boolean, initRequest: boolean) => {
+    const loadMedia = useCallback(async (url, lowLatencyMode: boolean, initRequest: boolean, podRetentionMinutes: number) => {
         let manifestUrl, adTrackingMetadataUrl;
         
         if (initRequest) {
@@ -246,6 +244,7 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
         setAdPods([]);
         setLastDataRange(null)
         adTrackerRef.current = new SimpleAdTracker();
+        adTrackerRef.current.setPodRetentionMinutes(podRetentionMinutes);
         const pods = adTrackerRef.current.getAdPods();
         adTrackerRef.current.addUpdateListener(() => {
             setAdPods([...pods]);  // trigger re-render
@@ -257,7 +256,8 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
             lowLatencyMode,
             initRequest,
             manifestUrl: manifestUrl,
-            adTrackingMetadataUrl: adTrackingMetadataUrl
+            adTrackingMetadataUrl: adTrackingMetadataUrl,
+            podRetentionMinutes,
         });
 
         await refreshMetadata(adTrackingMetadataUrl);
@@ -279,13 +279,14 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
             lowLatencyMode: sessionInfo.lowLatencyMode,
             initRequest: sessionInfo.initRequest,
             manifestUrl: null,
-            adTrackingMetadataUrl: ""
+            adTrackingMetadataUrl: "",
+            podRetentionMinutes: sessionInfo.podRetentionMinutes
         });
     }
 
     useEffect(() => {
         if (sessionInfo.mediaUrl && !sessionInfo.localSessionId) {
-            loadMedia(sessionInfo.mediaUrl, sessionInfo.lowLatencyMode, sessionInfo.initRequest);
+            loadMedia(sessionInfo.mediaUrl, sessionInfo.lowLatencyMode, sessionInfo.initRequest, sessionInfo.podRetentionMinutes);
         }
     }, [loadMedia, sessionInfo]);
 
@@ -294,24 +295,16 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
             return  // skip until initial range is fetched
         }
 
-        let useLiveMetadata = lastPlayheadTime > liveEdge - LIVE_METADATA_TIMESPAN_MS
-        if (useLiveMetadata) {
-            if (!lastDataRange.end || lastPlayheadTime + MIN_METADATA_LOOK_AHEAD_MS > lastDataRange.end) {
-                refreshMetadata(sessionInfo.adTrackingMetadataUrl);
-            }
-        } else if (!lastDataRange.end || lastPlayheadTime < lastDataRange.start || lastPlayheadTime > lastDataRange.end) {            
-            const url = new URL(sessionInfo.adTrackingMetadataUrl);
-            url.searchParams.append('start', lastPlayheadTime.toFixed(0));
-            refreshMetadata(url.toString());
-        }
+        // Always refresh metadata as duration of existing pods may change
+        await refreshMetadata(sessionInfo.adTrackingMetadataUrl);
     }, MIN_METADATA_INTERVAL_MS);
 
     const sessionContext: SessionContextInterface = {
         sessionInfo: sessionInfo,
         presentationStartTime: presentationStartTime,
-        load: (url, lowLatencyMode, initRequest) => {
+        load: (url, lowLatencyMode, initRequest, adExpirationMinutes) => {
             history.replace("?url=" + encodeURIComponent(url) + (lowLatencyMode ? "&low_latency=true" : ""));
-            return loadMedia(url, lowLatencyMode, initRequest);
+            return loadMedia(url, lowLatencyMode, initRequest, adExpirationMinutes);
         },
         unload: unload
     };
@@ -327,9 +320,6 @@ const AdTrackingPlaybackSessionProvider = (props: any) => {
         updatePlayheadTime: (time: number) => {
             setLastPlayheadTime(time);
             adTrackerRef.current?.updatePlayheadTime(time);
-        },
-        updateLiveEdge: (liveEdge: number) => {
-            setLiveEdge(liveEdge);
         },
         pause: () => adTrackerRef.current?.pause(),
         resume: () => adTrackerRef.current?.resume(),

--- a/src/InfoSection.tsx
+++ b/src/InfoSection.tsx
@@ -33,10 +33,12 @@ function InfoSection() {
 
   const [initRequest, setInitRequest] = useState(true);
 
+  const [podRetentionMinutes, setPodRetentionMinutes] = useState(120);
+
   const preventDefault = (event: MouseEvent<HTMLAnchorElement | HTMLSpanElement>) => event.preventDefault();
 
   const load = async () => {
-    await sessionContext.load(urlInputRef.current.value, lowLatencyChecked, initRequest);
+    await sessionContext.load(urlInputRef.current.value, lowLatencyChecked, initRequest, podRetentionMinutes);
   }
 
   const unload = () => {
@@ -48,7 +50,8 @@ function InfoSection() {
   }
 
   useEffect(() => {
-    setLowLatencyChecked(sessionInfo.lowLatencyMode)
+    setLowLatencyChecked(sessionInfo.lowLatencyMode);
+    setPodRetentionMinutes(sessionInfo.podRetentionMinutes);
   }, [sessionInfo])
 
   return (
@@ -67,6 +70,17 @@ function InfoSection() {
         Harmonic Client Side Ad Tracking Demo
       </Typography>
       <TextField inputRef={urlInputRef} label="Media URL" fullWidth={true} defaultValue={sessionInfo.mediaUrl || ''} variant={'standard'} />
+      <Box width={1} paddingTop={2} display="flex" flexDirection="row">
+        <TextField 
+          label="Ad Pod Retention (minutes)" 
+          type="number"
+          value={podRetentionMinutes}
+          onChange={(e) => setPodRetentionMinutes(parseInt(e.target.value, 10) || 120)}
+          variant={'standard'}
+          inputProps={{ min: 1 }}
+          helperText="Duration to keep ad pods in memory"
+        />
+      </Box>
       <Stack direction="row">
         <FormControlLabel
           control={<Checkbox checked={lowLatencyChecked} onChange={(e) => setLowLatencyChecked(e.target.checked)} />}

--- a/src/PlayerContainer.tsx
+++ b/src/PlayerContainer.tsx
@@ -37,13 +37,11 @@ function PlayerContainer() {
         setRawCurrentTime(time);
 
         if (sessionInfo.manifestUrl?.includes(".m3u8")) {
-            const presentationStartTime = shakaRef.current?.getPresentationStartTime()?.getTime() || 0;
             const clockTime = shakaRef.current?.getPlayheadTimeAsDate()?.getTime() || 0;
             setPlayhead(clockTime);
             setPlayheadInWallClock(clockTime);
             setMetadataTimeRange(adTrackingContext.metadataTimeRange);
             adTrackingContext.updatePlayheadTime(clockTime);
-            adTrackingContext.updateLiveEdge(presentationStartTime + (shakaRef.current?.getSeekRange()?.end ?? 0) * 1000)
         } else if (sessionInfo.manifestUrl?.includes(".mpd")) {            
             const mediaTime = Math.round(time * 1000);
             const presentationStartTime = shakaRef.current?.getPresentationStartTime()?.getTime() || 0;
@@ -58,7 +56,6 @@ function PlayerContainer() {
             setMetadataTimeRange(adTrackingContext.metadataTimeRange);
             adTrackingContext.updatePlayheadTime(mediaTime);
             adTrackingContext.updatePresentationStartTime(presentationStartTime);
-            adTrackingContext.updateLiveEdge((shakaRef.current?.getSeekRange()?.end ?? 0) * 1000)
         }
     };
 

--- a/src/SimpleAdTracker.tsx
+++ b/src/SimpleAdTracker.tsx
@@ -6,12 +6,17 @@ const MAX_TOLERANCE_IN_SPEED = 2;
 // Used for events that have zero duration & PRFT source switching
 const MAX_TOLERANCE_EVENT_END_TIME_MS = 1000;
 
-const mergePods = (existingPods: AdBreak[], pods: AdBreak[]) => {
+const mergePods = (existingPods: AdBreak[], pods: AdBreak[], lastPlayheadTime: number, podRetentionMs: number) => {
     let updated = false;
 
     for (let i = existingPods.length - 1; i >= 0; i--) {
-        const podId = existingPods[i].id;
-        if (!pods.find(p => p.id === podId)) {
+        const podEndTime = existingPods[i].startTime + existingPods[i].duration;
+        const timeSincePodEnded = lastPlayheadTime - podEndTime;
+        
+        // Keep the pod if it hasn't ended yet or if it's within the expiration window
+        const isPodActive = timeSincePodEnded < podRetentionMs;
+
+        if (!isPodActive) {
             existingPods.splice(i, 1);
             updated = true;
         }
@@ -41,13 +46,6 @@ const mergePods = (existingPods: AdBreak[], pods: AdBreak[]) => {
 const mergeAds = (existingAds: Ad[], ads: Ad[]) => {
     let updated = false;
 
-    for (let i = existingAds.length - 1; i >= 0; i--) {
-        const adId = existingAds[i].id;
-        if (!ads.find(a => a.id === adId)) {
-            existingAds.splice(i, 1);
-            updated = true;
-        }
-    }
     ads.forEach((ad) => {
         let existingAd = existingAds.find(a => a.id === ad.id);
         if (!existingAd) {
@@ -92,6 +90,7 @@ export default class SimpleAdTracker {
     private lastPlayheadUpdateTime: number;
     private listeners: (() => void)[];
     private companionAdListener: ((ad: Ad) => void);
+    private podRetentionMinutes: number;
 
     constructor() {
         this.adPods = [];
@@ -99,6 +98,7 @@ export default class SimpleAdTracker {
         this.lastPlayheadUpdateTime = 0;
         this.listeners = [];
         this.companionAdListener = () => {};
+        this.podRetentionMinutes = 120; // Default: 2 hours
     }
 
     addUpdateListener(listener: () => void) {
@@ -116,8 +116,13 @@ export default class SimpleAdTracker {
         this.companionAdListener = listener;
     }
 
+    setPodRetentionMinutes(minutes: number) {
+        this.podRetentionMinutes = minutes;
+    }
+
     updatePods(pods: AdBreak[]) {
-        const updated = mergePods(this.adPods, pods);
+        const podRetentionMs = this.podRetentionMinutes * 60 * 1000;
+        const updated = mergePods(this.adPods, pods, this.lastPlayheadTime, podRetentionMs);
         if (updated) {
             this.notifyListeners();
         }

--- a/types/AdTrackingContextInterface.d.ts
+++ b/types/AdTrackingContextInterface.d.ts
@@ -7,7 +7,6 @@ export default interface AdTrackingContextInterface {
     metadataTimeRange: DataRange | null
     updatePresentationStartTime: (time: number) => void
     updatePlayheadTime: (time: number) => void
-    updateLiveEdge: (liveEdge: number) => void
     pause: () => void
     resume: () => void
     mute: () => void

--- a/types/SessionContextInterface.d.ts
+++ b/types/SessionContextInterface.d.ts
@@ -5,9 +5,10 @@ export default interface SessionContextInterface {
         lowLatencyMode: boolean,
         initRequest: boolean,
         manifestUrl: string | null,
-        adTrackingMetadataUrl: string | null
+        adTrackingMetadataUrl: string | null,
+        podRetentionMinutes: number
     },
     presentationStartTime: number | null,
-    load: (url: any, lowLatency: boolean, initRequest: boolean) => Promise<void>,
+    load: (url: any, lowLatency: boolean, initRequest: boolean, podRetentionMinutes: number) => Promise<void>,
     unload: () => void
 }


### PR DESCRIPTION
The "start" query param for requests to the metadata API will be deprecated. This change removes the usage of it and caches all seen ad breaks with a customizable cache duration.